### PR TITLE
Fix package names for cli transport

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -207,8 +207,8 @@ Section: oldlibs
 Description: transitional package
  It's recommended to use the gz packages going forward.
 
-Package: libgz-transport11-cli
-Depends: libignition-transport11-cli (= ${binary:Version}), ${misc:Depends}
+Package: gz-transport11-cli
+Depends: ignition-transport11-cli (= ${binary:Version}), ${misc:Depends}
 Architecture: all
 Priority: optional
 Section: oldlibs


### PR DESCRIPTION
The debbuilder displays some problems in the QA checker. Particularly:
```
E: ignition-transport11 source: version-substvar-for-external-package Depends (line 211) ${binary:Version} libgz-transport11-cli -> libignition-transport11-cli
```
Probably means that `libignition-transport11-cli` does note exist. The cli package is not a library, so real name is `ignition-transport11-cli`. I've renamed the new package the dependency.